### PR TITLE
Add ROS graph refresh status indicator

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -240,6 +240,23 @@ body {
   margin: 0 0 10px 0;
 }
 
+.panel-header-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.panel-header-row h2 {
+  margin: 0;
+}
+
+.panel-header-row .status-pill {
+  white-space: normal;
+}
+
 .sim-mode-toggle {
   display: grid;
   gap: 8px;

--- a/src/components/RosNodeList.tsx
+++ b/src/components/RosNodeList.tsx
@@ -41,9 +41,16 @@ function RosNodeStatus({
         [requiredServices, rosGraph.missingRequiredServices]
     );
 
+    const graphRefreshLabel = rosGraph.lastUpdatedMs === null
+        ? 'Not yet refreshed'
+        : new Date(rosGraph.lastUpdatedMs).toLocaleString();
+
     return (
         <div className="dependency-panel">
-            <h2>Node and Dependency Status</h2>
+            <div className="panel-header-row">
+                <h2>Node and Dependency Status</h2>
+                <span className="status-pill neutral">Graph Refresh: {graphRefreshLabel}</span>
+            </div>
 
             <div className="dependency-grid">
                 <div className="dependency-card running">


### PR DESCRIPTION
Improves the ROS node status panel by adding a cleaner header row that shows the panel title along with the graph’s last refresh status. Also adds the CSS needed for the new layout, spacing, and alignment